### PR TITLE
follow redirects

### DIFF
--- a/lib/test_dispatch.ex
+++ b/lib/test_dispatch.ex
@@ -5,7 +5,7 @@ defmodule TestDispatch do
   templates will submit to the intended controller action with the right params.
   """
 
-  import Phoenix.ConnTest, only: [dispatch: 4]
+  import Phoenix.ConnTest, only: [dispatch: 4, redirected_to: 2]
   import Phoenix.Controller, only: [endpoint_module: 1]
   import TestDispatch.Form
   import TestDispatch.Link
@@ -108,5 +108,27 @@ defmodule TestDispatch do
     path = floki_attribute(link, "href")
 
     dispatch(conn, endpoint, method, path)
+  end
+
+  @doc """
+  Will take a conn that was redirected. It takes the path that was redirected to and
+  performs a get on it. If the status does not match the redirected status it will
+  raise an error. By default the status is 302.
+
+  ## Examples
+
+      iex> conn = build_conn() |> get("/posts/1")
+      iex> conn = dispatch_link(conn, "post-123-delete-post")
+      iex> result = follow_redirect(conn, 302) |> html_response(200)
+      iex> if result =~ "Posts Index", do: :ok
+      :ok
+
+  """
+  @spec follow_redirect(Plug.Conn.t(), integer) :: Plug.Conn.t()
+  def follow_redirect(conn, status \\ 302) do
+    path = redirected_to(conn, status)
+    endpoint = endpoint_module(conn)
+
+    dispatch(conn, endpoint, "get", path)
   end
 end

--- a/test/support/links/_post_index.html
+++ b/test/support/links/_post_index.html
@@ -10,7 +10,7 @@
 
 <body>
   <div>
-    <h1>Posts</h1>
+    <h1>Posts Index</h1>
     <ul>
       <li><a href="/posts/2" test-selector="post-index-1234-post-link" test-value="2"> Post 2 </a></li>
       <li><a href="/posts/1" test-selector="post-index-1234-post-link" test-value="1"> Post 1 </a></li>

--- a/test/test_dispatch_link_test.exs
+++ b/test/test_dispatch_link_test.exs
@@ -1,6 +1,6 @@
 defmodule TestDispatchLinkTest do
   use TestDispatch.ConnCase
-  doctest TestDispatch, import: true
+  doctest TestDispatch, import: true, only: [dispatch_link: 3]
 
   @post_show_body File.read!("test/support/links/_post_show.html")
 

--- a/test/test_dispatch_test.exs
+++ b/test/test_dispatch_test.exs
@@ -1,7 +1,7 @@
 defmodule TestDispatchTest do
   @moduledoc """
-  For the dispatch_link tests see `test/test_dispatch_link_test.exs`
-  for the `dispatch_form_with` tests see `test/test_dispatch_form_test.exs`
+  For the dispatch_link tests see `test/test_dispatch_link_test.exs`.
+  For the `dispatch_form_with` tests see `test/test_dispatch_form_test.exs`.
   """
 
   use TestDispatch.ConnCase

--- a/test/test_dispatch_test.exs
+++ b/test/test_dispatch_test.exs
@@ -1,0 +1,9 @@
+defmodule TestDispatchTest do
+  @moduledoc """
+  For the dispatch_link tests see `test/test_dispatch_link_test.exs`
+  for the `dispatch_form_with` tests see `test/test_dispatch_form_test.exs`
+  """
+
+  use TestDispatch.ConnCase
+  doctest TestDispatch, import: true, only: [follow_redirect: 2]
+end


### PR DESCRIPTION
When redirecting after a dispatch the page can contain new information
that needs to be checked on in tests. Therefore follow_redirect is
introduced so that the redirect can be folowed and a conn of the page
where is redirected to will be shown.