### PR TITLE
find and update radio buttons when no entity is given

### DIFF
--- a/lib/test_dispatch/form.ex
+++ b/lib/test_dispatch/form.ex
@@ -26,8 +26,7 @@ defmodule TestDispatch.Form do
     checked_names = Floki.attribute(checked, "name")
 
     other_radios =
-      form
-      |> Floki.find("input[type=radio]")
+      radios
       |> Enum.uniq_by(fn {_, list, _} ->
         list |> Enum.find(fn {key, _} -> "name" == key end) |> elem(1)
       end)

--- a/lib/test_dispatch/form.ex
+++ b/lib/test_dispatch/form.ex
@@ -91,7 +91,7 @@ defmodule TestDispatch.Form do
   end
 
   defp key_for_input(input, _) do
-    id = input |> floki_attribute("id")
+    id = floki_attribute(input, "id")
 
     key =
       if floki_attribute(input, "type") == "radio",

--- a/lib/test_dispatch/form.ex
+++ b/lib/test_dispatch/form.ex
@@ -13,19 +13,40 @@ defmodule TestDispatch.Form do
     fields = find_input_fields(form, "")
     selects = find_selects(form, "")
     textareas = find_textareas(form, "")
+    radio_buttons = find_radio_buttons(form, "")
 
-    Enum.uniq(fields ++ selects ++ textareas)
+    Enum.uniq(fields ++ selects ++ textareas ++ radio_buttons)
+  end
+
+  def find_radio_buttons(form, "") do
+    radios = Floki.find(form, "input[type=radio]")
+
+    checked = Enum.filter(radios, &floki_attribute(&1, "checked"))
+
+    checked_names = Floki.attribute(checked, "name")
+
+    other_radios =
+      form
+      |> Floki.find("input[type=radio]")
+      |> Enum.uniq_by(fn {_, list, _} ->
+        list |> Enum.find(fn {key, _} -> "name" == key end) |> elem(1)
+      end)
+      |> Enum.reject(fn radio -> floki_attribute(radio, "name") in checked_names end)
+
+    other_radios ++ checked
   end
 
   defp find_selects(form, _), do: Floki.find(form, "select")
 
   defp find_textareas(form, _), do: Floki.find(form, "textarea")
 
-  defp find_input_fields(form, {:entity, entity}), do: Floki.find(form, "*[id^=#{entity}_]")
+  defp find_input_fields(form, {:entity, entity}),
+    do: Floki.find(form, "*[id^=#{entity}_]") |> Floki.filter_out("input[type=radio]")
 
   defp find_input_fields(form, _),
     do:
       form
+      |> Floki.filter_out("input[type=radio]")
       |> Floki.filter_out("input[type=hidden]")
       |> Floki.find("input")
 
@@ -58,7 +79,16 @@ defmodule TestDispatch.Form do
       |> String.replace_prefix("#{entity}_", "")
       |> String.to_atom()
 
-  defp key_for_input(input, _), do: input |> floki_attribute("id") |> String.to_atom()
+  defp key_for_input(input, _) do
+    id = input |> floki_attribute("id")
+
+    key =
+      if floki_attribute(input, "type") == "radio",
+        do: String.replace_suffix(id, "_#{floki_attribute(input, "value")}", ""),
+        else: id
+
+    String.to_atom(key)
+  end
 
   def send_to_action(params, form, conn) do
     endpoint = endpoint_module(conn)

--- a/test/support/forms/_entity_and_form_controls.html
+++ b/test/support/forms/_entity_and_form_controls.html
@@ -33,6 +33,13 @@
         <option value="moderator">Moderator</option>
       </select>
 
+      <input type="radio" name="user[color]" id="user_color_red" value="red" checked />
+      <label for="color_red"> Color1 - Red</label>
+      <input type="radio" name="user[color]" id="user_color_green" value="green" />
+      <label for="color_green"> Color1 - Green</label>
+      <input type="radio" name="user[color]" id="user_color_blue" value="blue" />
+      <label for="color_blue"> Color1 - Blue</label>
+
       <button type="submit">Create new user</button>
     </form>
   </div>

--- a/test/support/forms/_only_form_controls.html
+++ b/test/support/forms/_only_form_controls.html
@@ -33,6 +33,13 @@
         <option value="moderator">Moderator</option>
       </select>
 
+      <input type="radio" name="color" id="color_red" value="red" checked />
+      <label for="color_red"> Color1 - Red</label>
+      <input type="radio" name="color" id="color_green" value="green" />
+      <label for="color_green"> Color1 - Green</label>
+      <input type="radio" name="color" id="color_blue" value="blue" />
+      <label for="color_blue"> Color1 - Blue</label>
+
       <button type="submit">Create new user</button>
     </form>
   </div>

--- a/test/test_dispatch_form_test.exs
+++ b/test/test_dispatch_form_test.exs
@@ -178,6 +178,7 @@ defmodule TestDispatch.FormTest do
         email: "john@doe.com",
         description: "Just a regular joe",
         roles: ["admin"],
+        color: "green",
         non_existing_field: "This will not show up in the params"
       }
 
@@ -193,7 +194,8 @@ defmodule TestDispatch.FormTest do
                "name" => "John Doe",
                "email" => "john@doe.com",
                "description" => "Just a regular joe",
-               "roles" => ["admin"]
+               "roles" => ["admin"],
+               "color" => "green"
              }
     end
 
@@ -210,7 +212,8 @@ defmodule TestDispatch.FormTest do
                "name" => nil,
                "email" => nil,
                "description" => "",
-               "roles" => nil
+               "roles" => nil,
+               "color" => "red"
              }
     end
   end

--- a/test/test_dispatch_form_test.exs
+++ b/test/test_dispatch_form_test.exs
@@ -8,7 +8,8 @@ defmodule TestDispatch.FormTest do
         email: "john@doe.com",
         description: "Just a regular joe",
         roles: ["admin", "moderator"],
-        non_existing_field: "This will not show up in the params"
+        non_existing_field: "This will not show up in the params",
+        color: "green"
       }
 
       %Plug.Conn{params: params} =
@@ -24,7 +25,8 @@ defmodule TestDispatch.FormTest do
                  "name" => "John Doe",
                  "email" => "john@doe.com",
                  "description" => "Just a regular joe",
-                 "roles" => ["admin", "moderator"]
+                 "roles" => ["admin", "moderator"],
+                 "color" => "green"
                }
              }
     end
@@ -49,7 +51,8 @@ defmodule TestDispatch.FormTest do
                  "name" => nil,
                  "email" => "john@doe.com",
                  "description" => "Just a regular joe",
-                 "roles" => ["admin", "moderator"]
+                 "roles" => ["admin", "moderator"],
+                 "color" => "red"
                }
              }
     end
@@ -68,7 +71,8 @@ defmodule TestDispatch.FormTest do
                  "name" => nil,
                  "email" => nil,
                  "description" => "",
-                 "roles" => nil
+                 "roles" => nil,
+                 "color" => "red"
                }
              }
     end


### PR DESCRIPTION
dispatch_form_with didn't respect the radio inputs where multiple inputs
are given with the same name. This commit ensures that when there isn't
an entity given the radio buttons are selected as should:

* A radio button that is selected with the checked attribute get's
  picked by default
* Only one radio button per name attribute is selected
* when attributes are given to dispatch_form_with the value will
  override the default

fixes #17