### PR TITLE
rename dispatch_form_with to dispatch_form

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ end
 ## Use
 
 Import TestDispatch in your test module or your test case and you can call
-`dispatch_form_with/3` from there.
+`dispatch_form/3` from there.
 
-To use `dispatch_form_with/3` a request has to be made to a page where a form is
-present. The conn that is received will be parsed by the `dispatch_form_with/3`
+To use `dispatch_form/3` a request has to be made to a page where a form is
+present. The conn that is received will be parsed by the `dispatch_form/3`
 and the form will be dispatched with the attributes that are given or the
 default values when they are not given.
 
@@ -50,7 +50,7 @@ defmodule MyAppWeb.MyTest do
 
     assert conn
            |> get(Routes.user_path(conn, :new))
-           |> dispatch_form_with(%{name: "John Doe", email: "john@doe.com"}, :user)
+           |> dispatch_form(%{name: "John Doe", email: "john@doe.com"}, :user)
            |> redirected_to(Routes.user_path(conn, :index))
   end
 
@@ -59,26 +59,26 @@ defmodule MyAppWeb.MyTest do
 
     assert conn
            |> get(Routes.user_path(conn, :index))
-           |> dispatch_form_with(User.IndexView.test_selector("batch-action"))
+           |> dispatch_form(User.IndexView.test_selector("batch-action"))
            |> html_response(200)
   end
 end
 ```
 
-`dispatch_form_with/3` will find a form in the HTML response of the given conn by
+`dispatch_form/3` will find a form in the HTML response of the given conn by
 entity or by [test_selector](https://github.com/DefactoSoftware/test_selector),
 or, if no entity or test_selector is provided, it will target the last form found
 in the response.
 
 Next it will look for form controls (inputs, selects), convert these to params
-and use the attributes passed to `dispatch_form_with/3` to update the values of
+and use the attributes passed to `dispatch_form/3` to update the values of
 the params. The params will now only contain field keys found in the controls of
 the form.
 
 If an entity is given, the params will be prepended by this entity. So for:
 
 ```elixir
-dispatch_form_with(conn, %{name: "John Doe", email: "john@doe.com"}, :user)
+dispatch_form(conn, %{name: "John Doe", email: "john@doe.com"}, :user)
 ```
 
 this will result in the following params:

--- a/guides/testing-with-test-dispatch.md
+++ b/guides/testing-with-test-dispatch.md
@@ -48,7 +48,7 @@ A request is made to the router here with the method `POST` to the action
 `/admin/users/create` and with the params `%{"user" => %{"name" => "",
 "email" => "", "description" => "", "roles" => ""}}`
 
-The `dispatch_form_with/3` will return a conn with the response of the
+The `dispatch_form/3` will return a conn with the response of the
 controller. In this case it has returned an error because all fields are left
 blank.
 
@@ -90,7 +90,7 @@ This form can be dispatched with
 ```elixir
 conn
 |> get("/admin/posts")
-|> dispatch_form_with("post-123-delete-post")
+|> dispatch_form("post-123-delete-post")
 |> html_response(200) =~ "Post is deleted"
 ```
 

--- a/lib/test_dispatch.ex
+++ b/lib/test_dispatch.ex
@@ -16,7 +16,7 @@ defmodule TestDispatch do
   the last form found in the response.
 
   Next it will look for form controls (inputs, selects), convert these to params
-  and use the attributes passed to `dispatch_form_with/3` to update the values
+  and use the attributes passed to `dispatch_form/3` to update the values
   of the params. The params will now only contain field keys found in the
   controls of the form.
 
@@ -26,10 +26,10 @@ defmodule TestDispatch do
   using `Phoenix.ConnTest.dispatch/5`, with the params and with the method and
   action found in the form.
   """
-  @spec dispatch_form_with(Plug.Conn.t(), %{}, binary() | atom() | nil) :: Plug.Conn.t()
-  def dispatch_form_with(conn, attrs \\ %{}, entity_or_test_selector \\ nil)
+  @spec dispatch_form(Plug.Conn.t(), %{}, binary() | atom() | nil) :: Plug.Conn.t()
+  def dispatch_form(conn, attrs \\ %{}, entity_or_test_selector \\ nil)
 
-  def dispatch_form_with(%Plug.Conn{} = conn, %{} = attrs, entity_or_test_selector)
+  def dispatch_form(%Plug.Conn{} = conn, %{} = attrs, entity_or_test_selector)
       when is_binary(entity_or_test_selector) or
              is_nil(entity_or_test_selector) or
              is_atom(entity_or_test_selector) do
@@ -44,8 +44,8 @@ defmodule TestDispatch do
     |> send_to_action(form, conn)
   end
 
-  def dispatch_form_with(conn, entity_or_test_selector, nil),
-    do: dispatch_form_with(conn, %{}, entity_or_test_selector)
+  def dispatch_form(conn, entity_or_test_selector, nil),
+    do: dispatch_form(conn, %{}, entity_or_test_selector)
 
   @doc """
   Finds a link by a given conn, test_selector and an optional test_value.

--- a/test/test_dispatch_form_test.exs
+++ b/test/test_dispatch_form_test.exs
@@ -16,7 +16,7 @@ defmodule TestDispatch.FormTest do
         dispatched_conn =
         conn
         |> get("/users/new", %{form: "entity_and_form_controls"})
-        |> dispatch_form_with(attrs, :user)
+        |> dispatch_form(attrs, :user)
 
       assert html_response(dispatched_conn, 200) == "user created"
 
@@ -42,7 +42,7 @@ defmodule TestDispatch.FormTest do
         dispatched_conn =
         conn
         |> get("/users/new", %{form: "entity_and_form_controls"})
-        |> dispatch_form_with(attrs, :user)
+        |> dispatch_form(attrs, :user)
 
       assert html_response(dispatched_conn, 200) == "not all required params are set"
 
@@ -62,7 +62,7 @@ defmodule TestDispatch.FormTest do
         dispatched_conn =
         conn
         |> get("/users/new", %{form: "entity_and_form_controls"})
-        |> dispatch_form_with(:user)
+        |> dispatch_form(:user)
 
       assert html_response(dispatched_conn, 200) == "not all required params are set"
 
@@ -89,7 +89,7 @@ defmodule TestDispatch.FormTest do
         dispatched_conn =
         conn
         |> get("/users/new", %{form: "lacking_required_form_controls"})
-        |> dispatch_form_with(attrs, :user)
+        |> dispatch_form(attrs, :user)
 
       assert html_response(dispatched_conn, 200) == "not all required params are set"
 
@@ -116,7 +116,7 @@ defmodule TestDispatch.FormTest do
         dispatched_conn =
         conn
         |> get("/users/new", %{form: "test_selector_and_form_controls"})
-        |> dispatch_form_with(attrs, "new-user")
+        |> dispatch_form(attrs, "new-user")
 
       assert html_response(dispatched_conn, 200) == "user created"
 
@@ -133,7 +133,7 @@ defmodule TestDispatch.FormTest do
         dispatched_conn =
         conn
         |> get("/users/new", %{form: "test_selector_and_form_controls"})
-        |> dispatch_form_with("new-user")
+        |> dispatch_form("new-user")
 
       assert html_response(dispatched_conn, 200) == "not all required params are set"
 
@@ -152,7 +152,7 @@ defmodule TestDispatch.FormTest do
         dispatched_conn =
         conn
         |> get("/users/index")
-        |> dispatch_form_with("export-users")
+        |> dispatch_form("export-users")
 
       assert html_response(dispatched_conn, 200) == "users exported"
       assert params == %{}
@@ -168,7 +168,7 @@ defmodule TestDispatch.FormTest do
         dispatched_conn =
         conn
         |> get("/users/index")
-        |> dispatch_form_with(attrs, "export-users")
+        |> dispatch_form(attrs, "export-users")
 
       assert html_response(dispatched_conn, 200) == "users exported"
       assert params == %{}
@@ -190,7 +190,7 @@ defmodule TestDispatch.FormTest do
         dispatched_conn =
         conn
         |> get("/users/new", %{form: "only_form_controls"})
-        |> dispatch_form_with(attrs)
+        |> dispatch_form(attrs)
 
       assert html_response(dispatched_conn, 200) == "user created"
 
@@ -208,7 +208,7 @@ defmodule TestDispatch.FormTest do
         dispatched_conn =
         conn
         |> get("/users/new", %{form: "only_form_controls"})
-        |> dispatch_form_with(%{})
+        |> dispatch_form(%{})
 
       assert html_response(dispatched_conn, 200) == "not all required params are set"
 
@@ -228,7 +228,7 @@ defmodule TestDispatch.FormTest do
         dispatched_conn =
         conn
         |> get("/users/index")
-        |> dispatch_form_with()
+        |> dispatch_form()
 
       assert html_response(dispatched_conn, 200) == "users exported"
       assert params == %{}
@@ -245,7 +245,7 @@ defmodule TestDispatch.FormTest do
         dispatched_conn =
         conn
         |> get("/users/index")
-        |> dispatch_form_with(attrs)
+        |> dispatch_form(attrs)
 
       assert html_response(dispatched_conn, 200) == "users exported"
       assert params == %{}
@@ -259,7 +259,7 @@ defmodule TestDispatch.FormTest do
       RuntimeError,
       "No form found for the given test_selector or entity: new-user",
       fn ->
-        dispatch_form_with(conn, "new-user")
+        dispatch_form(conn, "new-user")
       end
     )
   end
@@ -268,7 +268,7 @@ defmodule TestDispatch.FormTest do
     conn = get(conn, "/users/new", %{form: "only_form_controls"})
 
     assert_raise(RuntimeError, "No form found for the given test_selector or entity: user", fn ->
-      dispatch_form_with(conn, :user)
+      dispatch_form(conn, :user)
     end)
   end
 
@@ -279,7 +279,7 @@ defmodule TestDispatch.FormTest do
       |> Plug.Conn.resp(200, "no form here")
 
     assert_raise(RuntimeError, "No form found for the given test_selector or entity: user", fn ->
-      dispatch_form_with(conn, :user)
+      dispatch_form(conn, :user)
     end)
   end
 end

--- a/test/test_dispatch_test.exs
+++ b/test/test_dispatch_test.exs
@@ -1,7 +1,7 @@
 defmodule TestDispatchTest do
   @moduledoc """
   For the dispatch_link tests see `test/test_dispatch_link_test.exs`.
-  For the `dispatch_form_with` tests see `test/test_dispatch_form_test.exs`.
+  For the `dispatch_form` tests see `test/test_dispatch_form_test.exs`.
   """
 
   use TestDispatch.ConnCase


### PR DESCRIPTION
This aligns with the dispatch_link has a clearer use.