### PR TITLE
dipatch_form/4 can use both entity and test_selector

### DIFF
--- a/lib/test_dispatch.ex
+++ b/lib/test_dispatch.ex
@@ -47,6 +47,10 @@ defmodule TestDispatch do
   def dispatch_form(conn, entity_or_test_selector, nil),
     do: dispatch_form(conn, %{}, entity_or_test_selector)
 
+  @doc """
+  Works like `dispatch/3`. The test_selector is used to find the right form and the
+  entity is used to find and fill the inputs correctly.
+  """
   @spec dispatch_form(Plug.Conn.t(), %{}, atom(), binary()) :: Plug.Conn.t()
 
   def dispatch_form(%Plug.Conn{} = conn, %{} = attrs, entity, test_selector) do

--- a/lib/test_dispatch.ex
+++ b/lib/test_dispatch.ex
@@ -47,6 +47,20 @@ defmodule TestDispatch do
   def dispatch_form(conn, entity_or_test_selector, nil),
     do: dispatch_form(conn, %{}, entity_or_test_selector)
 
+  @spec dispatch_form(Plug.Conn.t(), %{}, atom(), binary()) :: Plug.Conn.t()
+
+  def dispatch_form(%Plug.Conn{} = conn, %{} = attrs, entity, test_selector) do
+    {form, _} = find_form(conn, test_selector)
+    selector_tuple = {:entity, entity}
+
+    form
+    |> find_inputs(selector_tuple)
+    |> Enum.map(&input_to_tuple(&1, selector_tuple))
+    |> update_input_values(attrs)
+    |> prepend_entity(selector_tuple)
+    |> send_to_action(form, conn)
+  end
+
   @doc """
   Finds a link by a given conn, test_selector and an optional test_value.
 

--- a/test/support/forms/_multiple_selector_and_form_controls.html
+++ b/test/support/forms/_multiple_selector_and_form_controls.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html>
+<head>
+  <title>New user</title>
+
+  <meta charset="utf-8" />
+  <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+
+<body>
+  <div>
+    <h1>New user</h1>
+    <form action="/" method="post">
+      <button type="submit">Random other form</button>
+    </form>
+
+    <form action="/users/1" method="put" test-selector="user-profile">
+      <input name="_csrf_token" type="hidden" value="AHIqJmEUAxIvGy4HJ3oUGCMjChsLYBZ-SGgy7W1HElh3PKLsffgXXQO6">
+
+      <label>Name</label>
+      <input id="user_name" label="Name" name="user[name]" type="text">
+
+      <label>Email</label>
+      <input id="user_email" label="Email" name="user[email]" type="email">
+
+      <label>Description</label>
+      <textarea id="user_description" label="Description" name="user[description]" type="textarea"></textarea>
+
+      <select id="user_roles" name="user[roles]">
+        <option value="">Select a role</option>
+        <option value="admin">Admin</option>
+        <option value="moderator">Moderator</option>
+      </select>
+
+      <button type="submit">Update Profile</button>
+    </form>
+
+    <form action="/users/create" method="put" test-selector="user-account">
+      <input name="_csrf_token" type="hidden" value="AHIqJmEUAxIvGy4HJ3oUGCMjChsLYBZ-SGgy7W1HElh3PKLsffgXXQO6">
+
+      <label>Email</label>
+      <input id="email"  name="email" type="email">
+
+      <label>Password Confirmation</label>
+      <input id="password" type="password">
+
+      <button type="submit">Update Account details</button>
+    </form>
+  </div>
+</body>
+</html>

--- a/test/support/test_controller.ex
+++ b/test/support/test_controller.ex
@@ -28,6 +28,12 @@ defmodule TestDispatchTest.Controller do
       else: set_html_resp(conn, 200, "not all required params are set")
   end
 
+  def call(%{params: params} = conn, :update) do
+    if has_all_required_params?(params),
+      do: set_html_resp(conn, 200, "user updated"),
+      else: set_html_resp(conn, 200, "not all required params are set")
+  end
+
   def call(conn, :export) do
     set_html_resp(conn, 200, "users exported")
   end

--- a/test/support/test_router.ex
+++ b/test/support/test_router.ex
@@ -12,6 +12,7 @@ defmodule TestDispatchTest.Router do
     get("/users/index", Controller, :index)
     get("/users/new", Controller, :new)
     post("/users/create", Controller, :create)
+    put("/users/:id", Controller, :update)
     post("/users/export", Controller, :export)
 
     get("/posts", PostController, :index)

--- a/test/test_dispatch_form_test.exs
+++ b/test/test_dispatch_form_test.exs
@@ -282,4 +282,35 @@ defmodule TestDispatch.FormTest do
       dispatch_form(conn, :user)
     end)
   end
+
+  describe "form with entity AND test_selector" do
+    test "use both the entity and selector to dispatch the right form", %{conn: conn} do
+      attrs = %{
+        name: "John Doe",
+        email: "john@doe.com",
+        description: "Just a regular joe",
+        roles: ["admin", "moderator"],
+        non_existing_field: "This will not show up in the params",
+        color: "green"
+      }
+
+      %Plug.Conn{params: params} =
+        dispatched_conn =
+        conn
+        |> get("/users/new", %{form: "multiple_selector_and_form_controls"})
+        |> dispatch_form(attrs, :user, "user-profile")
+
+      assert html_response(dispatched_conn, 200) == "not all required params are set"
+
+      assert params == %{
+               "id" => "1",
+               "user" => %{
+                 "description" => "Just a regular joe",
+                 "email" => "john@doe.com",
+                 "name" => "John Doe",
+                 "roles" => ["admin", "moderator"]
+               }
+             }
+    end
+  end
 end


### PR DESCRIPTION
When a form is selected with a test_selector but the items are using the
entity for each field we want to split up the attributes in a map within
a map.

This commit introduces `dispatch_form/4` that with the entity as third and
test_selector as fourth param. It will find the right form by the
test_selector and uses the entity to find the inputs and update the
right values