### PR TITLE
Add possibility to dispatch nested inputs

### DIFF
--- a/lib/test_dispatch/form.ex
+++ b/lib/test_dispatch/form.ex
@@ -115,8 +115,7 @@ defmodule TestDispatch.Form do
       [key, capture, nested_key] ->
         index =
           capture
-          |> String.replace_prefix("_", "")
-          |> String.replace_suffix("_", "")
+          |> String.replace("_", "")
           |> String.to_integer()
 
         {String.to_atom(key), index, String.to_atom(nested_key)}

--- a/test/support/forms/_entity_and_form_controls.html
+++ b/test/support/forms/_entity_and_form_controls.html
@@ -40,6 +40,13 @@
       <input type="radio" name="user[color]" id="user_color_blue" value="blue" />
       <label for="color_blue"> Color1 - Blue</label>
 
+      <label>Cats</label>
+      <input id="user_cats_0_name" label="Cats" name="user[cats][0][name]" type="text">
+      <input id="user_cats_0_age" label="Cats" name="user[cats][0][age]" type="number">
+
+      <input id="user_cats_1_name" label="Cats" name="user[cats][1][name]" type="text">
+      <input id="user_cats_1_age" label="Cats" name="user[cats][1][age]" type="number">
+
       <button type="submit">Create new user</button>
     </form>
   </div>

--- a/test/test_dispatch_form_test.exs
+++ b/test/test_dispatch_form_test.exs
@@ -9,7 +9,8 @@ defmodule TestDispatch.FormTest do
         description: "Just a regular joe",
         roles: ["admin", "moderator"],
         non_existing_field: "This will not show up in the params",
-        color: "green"
+        color: "green",
+        cats: [%{name: "Joe", age: 21}, %{name: "Jane", age: 8}]
       }
 
       %Plug.Conn{params: params} =
@@ -26,7 +27,8 @@ defmodule TestDispatch.FormTest do
                  "email" => "john@doe.com",
                  "description" => "Just a regular joe",
                  "roles" => ["admin", "moderator"],
-                 "color" => "green"
+                 "color" => "green",
+                 "cats" => [%{"name" => "Joe", "age" => 21}, %{"name" => "Jane", "age" => 8}]
                }
              }
     end
@@ -52,6 +54,7 @@ defmodule TestDispatch.FormTest do
                  "email" => "john@doe.com",
                  "description" => "Just a regular joe",
                  "roles" => ["admin", "moderator"],
+                 "cats" => [%{"name" => nil, "age" => nil}, %{"name" => nil, "age" => nil}],
                  "color" => "red"
                }
              }
@@ -72,6 +75,7 @@ defmodule TestDispatch.FormTest do
                  "email" => nil,
                  "description" => "",
                  "roles" => nil,
+                 "cats" => [%{"name" => nil, "age" => nil}, %{"name" => nil, "age" => nil}],
                  "color" => "red"
                }
              }


### PR DESCRIPTION
When using Phoenix' inputs_for, inputs will be created with id's
containing the index and nested key names. This change will add the
possibility to find and update input values of those fields. One level
deep only.