### PR TITLE
Match nestings when an entity is not given

### DIFF
--- a/lib/test_dispatch/form.ex
+++ b/lib/test_dispatch/form.ex
@@ -115,11 +115,8 @@ defmodule TestDispatch.Form do
   defp _input_to_tuple("select", input),
     do: input |> Floki.find("option[selected=selected]") |> floki_attribute("value")
 
-  defp key_for_input(input, {:entity, entity}) do
-    name = floki_attribute(input, "name")
-
-    String.replace_prefix(name, "#{entity}", "")
-  end
+  defp key_for_input(input, {:entity, entity}),
+    do: input |> floki_attribute("name") |> String.replace_prefix("#{entity}", "")
 
   defp key_for_input(input, _), do: floki_attribute(input, "name")
 

--- a/lib/test_dispatch/form.ex
+++ b/lib/test_dispatch/form.ex
@@ -87,25 +87,25 @@ defmodule TestDispatch.Form do
   def prepend_entity(attrs, _), do: attrs
 
   def update_input_values(list, attrs \\ %{}) do
-    Enum.reduce(list, %{}, fn item, acc ->
-      case item do
-        {key, value} ->
-          Map.put(acc, key, Map.get(attrs, key, value))
+    Enum.reduce(list, %{}, fn {keys, form_value}, acc ->
+      keys = Enum.map(keys, &String.to_atom/1)
+      value = get_in(attrs, keys) || form_value
 
-        {key, index, {nested_key, value}} = tuple ->
-          nested_attr =
-            attrs |> Map.get(key, []) |> Enum.at(index, %{}) |> Map.get(nested_key, value)
-
-          acc_nested_list = Map.get(acc, key, false)
-          new_nested_list = update_nested_input_values(acc_nested_list, tuple, nested_attr)
-
-          Map.put(acc, key, new_nested_list)
-
-        _ ->
-          acc
-      end
+      keys
+      |> Enum.reverse()
+      |> Enum.reduce(value, &Map.new([{&1, &2}]))
+      |> Enum.into(%{})
+      |> deep_merge(acc)
     end)
   end
+
+  defp deep_merge(map1, map2) when is_map(map1) and is_map(map2) do
+    Map.merge(map1, map2, fn _key, value_1, value2 ->
+      deep_merge(value_1, value2)
+    end)
+  end
+
+  defp deep_merge(_original, preceding), do: preceding
 
   def input_to_tuple(input, entity_tuple) do
     value = input |> elem(0) |> _input_to_tuple([input])
@@ -125,14 +125,9 @@ defmodule TestDispatch.Form do
     do: input |> Floki.find("option[selected=selected]") |> floki_attribute("value")
 
   defp key_for_input(input, {:entity, entity}) do
-    id = input |> floki_attribute("id")
+    id = input |> floki_attribute("name")
 
-    key =
-      if floki_attribute(input, "type") == "radio",
-        do: String.replace_suffix(id, "_#{floki_attribute(input, "value")}", ""),
-        else: id
-
-    String.replace_prefix(key, "#{entity}_", "")
+    String.replace_prefix(id, "#{entity}", "")
   end
 
   defp key_for_input({"button", _, _} = input, _), do: floki_attribute(input, "name")
@@ -143,25 +138,12 @@ defmodule TestDispatch.Form do
 
     if floki_attribute(input, "type") == "radio",
       do: name,
-      else: id
+      else: name
   end
 
   defp resolve_nested(nil), do: nil
 
-  defp resolve_nested(key) do
-    case Regex.split(~r{_\d*_}, key, include_captures: true) do
-      [key, capture, nested_key] ->
-        index =
-          capture
-          |> String.replace("_", "")
-          |> String.to_integer()
-
-        {String.to_atom(key), index, String.to_atom(nested_key)}
-
-      _ ->
-        String.to_atom(key)
-    end
-  end
+  defp resolve_nested(key), do: String.split(key, ["[", "]"], trim: true)
 
   defp update_nested_input_values(false, {_, _, {nested_key, _}}, nested_attr),
     do: [Map.put(%{}, nested_key, nested_attr)]

--- a/lib/test_dispatch/form.ex
+++ b/lib/test_dispatch/form.ex
@@ -116,20 +116,12 @@ defmodule TestDispatch.Form do
     do: input |> Floki.find("option[selected=selected]") |> floki_attribute("value")
 
   defp key_for_input(input, {:entity, entity}) do
-    name = input |> floki_attribute("name")
+    name = floki_attribute(input, "name")
 
     String.replace_prefix(name, "#{entity}", "")
   end
 
-  defp key_for_input({"button", _, _} = input, _), do: floki_attribute(input, "name")
-
-  defp key_for_input(input, _) do
-    name = floki_attribute(input, "name")
-
-    if floki_attribute(input, "type") == "radio",
-      do: name,
-      else: name
-  end
+  defp key_for_input(input, _), do: floki_attribute(input, "name")
 
   defp resolve_nested(nil), do: nil
 

--- a/lib/test_dispatch/form.ex
+++ b/lib/test_dispatch/form.ex
@@ -116,9 +116,9 @@ defmodule TestDispatch.Form do
     do: input |> Floki.find("option[selected=selected]") |> floki_attribute("value")
 
   defp key_for_input(input, {:entity, entity}) do
-    id = input |> floki_attribute("name")
+    name = input |> floki_attribute("name")
 
-    String.replace_prefix(id, "#{entity}", "")
+    String.replace_prefix(name, "#{entity}", "")
   end
 
   defp key_for_input({"button", _, _} = input, _), do: floki_attribute(input, "name")

--- a/test/test_dispatch_form_test.exs
+++ b/test/test_dispatch_form_test.exs
@@ -28,7 +28,10 @@ defmodule TestDispatch.FormTest do
                  "description" => "Just a regular joe",
                  "roles" => ["admin", "moderator"],
                  "color" => "green",
-                 "cats" => [%{"name" => "Joe", "age" => 21}, %{"name" => "Jane", "age" => 8}]
+                 "cats" => %{
+                   "0" => %{"age" => nil, "name" => nil},
+                   "1" => %{"age" => nil, "name" => nil}
+                 }
                }
              }
     end
@@ -54,7 +57,10 @@ defmodule TestDispatch.FormTest do
                  "email" => "john@doe.com",
                  "description" => "Just a regular joe",
                  "roles" => ["admin", "moderator"],
-                 "cats" => [%{"name" => nil, "age" => nil}, %{"name" => nil, "age" => nil}],
+                 "cats" => %{
+                   "0" => %{"name" => nil, "age" => nil},
+                   "1" => %{"name" => nil, "age" => nil}
+                 },
                  "color" => "red"
                }
              }
@@ -75,7 +81,10 @@ defmodule TestDispatch.FormTest do
                  "email" => nil,
                  "description" => "",
                  "roles" => nil,
-                 "cats" => [%{"name" => nil, "age" => nil}, %{"name" => nil, "age" => nil}],
+                 "cats" => %{
+                   "0" => %{"age" => nil, "name" => nil},
+                   "1" => %{"age" => nil, "name" => nil}
+                 },
                  "color" => "red"
                }
              }


### PR DESCRIPTION
When submitting a form with the structure `course[subject][part]`
is set as the name of a field a typicle match in the controller could be
```ex
def post(conn, %{"course" => %{"subject" => %{"part" => part_value}}}) do
```

But this is not send by us, instead what we sent will resolve as
`%{"course_subject_part" => part_value}`.

In this commit I'm trying to solve this by getting the keys from the
name attribute instead of the id. This is easier to match on and the
regex can be replaced with a simple `String.split/3`

I was a bit confused by the tests that i've adjusted, where we match the
params with `cats => %{ ... }`. Before this commit there weren't any
numbers even though they were specified and to my understanding they
should be there as they are now. Please let me know if I missed
something here.