### PR TITLE
Remove all cases of dispatch_form and dispatch_link

### DIFF
--- a/test/test_dispatch_test.exs
+++ b/test/test_dispatch_test.exs
@@ -5,5 +5,6 @@ defmodule TestDispatchTest do
   """
 
   use TestDispatch.ConnCase
+
   doctest TestDispatch, import: true, only: [follow_redirect: 2, receive_mail: 2]
 end


### PR DESCRIPTION
They've been replaced with submit_form and click_link already and
keeping them in the code only decreases readablity.