### PR TITLE
Set default actions for forms

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,31 +1,3 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# third-party users, it should be done in your "mix.exs" file.
-
-# You can configure your application as:
-#
-#     config :test_dispatch, key: :value
-#
-# and access this configuration in your application as:
-#
-#     Application.get_env(:test_dispatch, :key)
-#
-# You can also configure a third-party app:
-#
-#     config :logger, level: :info
-#
 config :phoenix, :json_library, Jason
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env()}.exs"

--- a/lib/test_dispatch/form.ex
+++ b/lib/test_dispatch/form.ex
@@ -110,10 +110,12 @@ defmodule TestDispatch.Form do
 
   defp resolve_nested(key), do: String.split(key, ["[", "]"], trim: true)
 
+  @spec send_to_action(map() | Keyword.t(), binary(), Plug.Conn.t()) :: Plug.Conn.t()
   def send_to_action(params, form, conn) do
     endpoint = endpoint_module(conn)
     method = get_method_of_form(form)
-    action = floki_attribute(form, "action")
+
+    action = floki_attribute(form, "action") || conn.request_path
 
     dispatch(conn, endpoint, method, action, params)
   end
@@ -131,6 +133,7 @@ defmodule TestDispatch.Form do
   defp downcase(nil), do: nil
   defp downcase(string), do: String.downcase(string)
 
+  @spec find_form(Plug.Conn.t(), binary() | Keyword.t() | tuple()) :: {binary(), atom()}
   def find_form(%Plug.Conn{status: status} = conn, entity_or_test_selector)
       when status in 200..299 or status == 401 do
     conn

--- a/test/test_dispatch/form_test.exs
+++ b/test/test_dispatch/form_test.exs
@@ -1,0 +1,25 @@
+defmodule TestDispatch.FormTest do
+  use TestDispatch.ConnCase
+
+  @params %{
+    user: %{
+      roles: ["admin", "moderator"]
+    }
+  }
+  setup %{conn: conn} do
+    conn = Plug.Conn.put_private(conn, :phoenix_endpoint, @endpoint)
+    {:ok, conn: conn}
+  end
+
+  describe "#send_to_action/3" do
+    test "Send a request to the current path when no action is given", %{conn: conn} do
+      conn = get(conn, "/users/index")
+
+      form =
+        {"form", [{"method", "get"}],
+         [{"input", [{"name", "_method"}, {"type", "hidden"}, {"value", "get"}], []}]}
+
+      assert TestDispatch.Form.send_to_action(@params, form, conn).request_path == "/users/index"
+    end
+  end
+end


### PR DESCRIPTION
When a form does not have an explicit action set it will do the action
to the current url.